### PR TITLE
Add CI workflow for building and releasing APK

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,62 @@
+name: Build and Release
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+  build-and-release:
+    if: startsWith(github.event.pull_request.title, 'releases')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+
+      - name: Build APK
+        run: ./gradlew assembleRelease
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.sha }}
+          release_name: Release ${{ github.sha }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: app/build/outputs/apk/release/app-release.apk
+          asset_name: app-release.apk
+          asset_content_type: application/vnd.android.package-archive

--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Credits
 Special thanks to [sinasamaki](https://github.com/sinasamaki) for creating the guide to create wonderful UI. Check out his [YouTube channel](https://www.youtube.com/@sinasamaki) and [website](https://www.sinasamaki.com/) for more amazing content. If you find his work helpful, consider buying a subscription on his [premium website](https://www.sinasamaki.com/premium/).
+
+## Continuous Integration
+This project uses GitHub Actions for continuous integration. The workflow file `build-and-release.yml` is located in the `.github/workflows/` directory. It verifies the Android Jetpack Compose app, builds the APK if the pull request title starts with "releases", and releases the APK if the pull request title starts with "releases".


### PR DESCRIPTION
Add a GitHub Actions workflow to verify, build, and release the Android Jetpack Compose app.

* **README.md**
  - Add a new section "Continuous Integration" to describe the new GitHub Actions workflow.
  - Mention the workflow file `build-and-release.yml` in the new section.

* **.github/workflows/build-and-release.yml**
  - Create a new GitHub Actions workflow file.
  - Define a job to verify the Android Jetpack Compose app.
  - Define a job to build the APK if the pull request title starts with "releases".
  - Define a job to release the APK if the pull request title starts with "releases".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Akshar062/Material-Masterpieces/pull/3?shareId=98c0f319-fd5a-4c55-9a59-9de59cc8675a).